### PR TITLE
fix: CoW-style appcode and github CI/CD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Docker Image CI/CD
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  docker-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      
+      - name: Login to Docker Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Retrieve Image Metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          labels: |
+            org.opencontainers.image.licenses=LGPL-3.0-or-later
+      
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref }}
+            ghcr.io/${{ github.repository }}:latest
+          labels: ${{ steps.meta.outputs.labels }}

--- a/ts/cowfee.ts
+++ b/ts/cowfee.ts
@@ -132,7 +132,7 @@ export const getTokensToSwap = async (
 // get COWFeeModule appData
 export const getAppData = async () => {
   const metadataApi = new MetadataApi();
-  const appCode = 'COWFeeModule';
+  const appCode = 'CoWFeeModule';
   const environment = 'prod';
   const appDataDoc = await metadataApi.generateAppDataDoc({
     appCode,


### PR DESCRIPTION
This PR:

1. Modifies the `appCode`, setting it to `CoWFeeModule` to match that of the module that's already deployed.
2. Provides a GitHub CI/CD pipeline for docker image production, required for the `CronJob`.