### PR TITLE
 feat: add minOut check on the buyAmount

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Options:
   --network <network>                                   (choices: "mainnet", "gnosis")
   --rpc-url <rpc-url>
   --max-orders <max-orders>                            Maximum number of orders to place in single drip call (default: 250)
-  --min-out <min-out>                                  Minimum amount of to-token to receive per swap (default: 0.02)
   --buy-amount-slippage-bps <buy-amount-slippage-bps>  Tolerance to add to the quoted buyAmount (default: 100)
   --module <module>                                    COWFeeModule address
   --token-list-strategy <strategy>                     Strategy to use to get the list of tokens to swap on (choices: "explorer", "chain", default: "explorer")

--- a/index.ts
+++ b/index.ts
@@ -112,12 +112,6 @@ const readConfig = async (): Promise<
     throw new Error('Keeper key mismatch');
   }
 
-  const toTokenDecimals = await new ethers.Contract(
-    toToken,
-    erc20Abi,
-    provider
-  ).decimals();
-
   return [
     {
       privateKey,
@@ -131,7 +125,6 @@ const readConfig = async (): Promise<
       buyToken: toToken,
       minOut,
       receiver,
-      buyTokenDecimals: toTokenDecimals,
       buyAmountSlippageBps,
       keeper,
       appData,

--- a/index.ts
+++ b/index.ts
@@ -72,7 +72,6 @@ const readConfig = async (): Promise<
   const {
     network: selectedNetwork,
     maxOrders,
-    minOut,
     buyAmountSlippageBps,
     module: selectedModule,
     lookbackRange,
@@ -95,6 +94,7 @@ const readConfig = async (): Promise<
     keeper,
     appData,
     targetSafe,
+    minOut,
   ] = await Promise.all([
     moduleContract.receiver(),
     moduleContract.toToken(),
@@ -103,6 +103,7 @@ const readConfig = async (): Promise<
     moduleContract.keeper(),
     moduleContract.appData(),
     moduleContract.targetSafe(),
+    moduleContract.minOut(),
   ]);
   if (
     (await new ethers.Wallet(privateKey).getAddress()).toLowerCase() !==

--- a/index.ts
+++ b/index.ts
@@ -34,14 +34,6 @@ const readConfig = async (): Promise<
     )
     .addOption(
       new Option(
-        '--min-out <min-out>',
-        'Minimum amount of to-token to receive per swap'
-      )
-        .default(0.02)
-        .argParser((x) => +x)
-    )
-    .addOption(
-      new Option(
         '--buy-amount-slippage-bps <buy-amount-slippage-bps>',
         'Tolerance to add to the quoted buyAmount'
       )
@@ -151,7 +143,7 @@ export const dripItAll = async () => {
       token.symbol,
       token.address,
       formatUnits(token.balance, token.decimals),
-      token.tokenOut,
+      token.buyAmount,
       token.needsApproval,
     ])
   );

--- a/script/COWFeeModule.s.sol
+++ b/script/COWFeeModule.s.sol
@@ -10,9 +10,10 @@ contract COWFeeModuleDeployScript is Script {
         bytes32 appData = vm.envBytes32("APP_DATA");
         bool shouldEnableModule = vm.envBool("SHOULD_ENABLE_MODULE");
         address targetSafe = vm.envAddress("TARGET_SAFE");
+        uint256 minOut = vm.envUint("MIN_OUT");
 
         vm.broadcast();
-        COWFeeModule module = new COWFeeModule(settlement, targetSafe, toToken, keeper, appData, receiver);
+        COWFeeModule module = new COWFeeModule(settlement, targetSafe, toToken, keeper, appData, receiver, minOut);
 
         // only useful for local anvil setup
         if (shouldEnableModule) {

--- a/test/COWFeeModule.t.sol
+++ b/test/COWFeeModule.t.sol
@@ -99,7 +99,7 @@ contract COWFeeModuleTest is Test {
                 buyToken: IERC20(WETH),
                 receiver: receiver,
                 sellAmount: 100 ether,
-                buyAmount: 1,
+                buyAmount: minOut,
                 validTo: nextValidTo,
                 appData: bytes32(0),
                 feeAmount: 0,
@@ -113,7 +113,7 @@ contract COWFeeModuleTest is Test {
         bytes memory preSignature = abi.encodePacked(orderHash, address(settlement), nextValidTo);
 
         COWFeeModule.SwapToken[] memory swapTokens = new COWFeeModule.SwapToken[](1);
-        swapTokens[0] = COWFeeModule.SwapToken({ token: address(mockToken), buyAmount: 1, sellAmount: 100 ether });
+        swapTokens[0] = COWFeeModule.SwapToken({ token: address(mockToken), buyAmount: minOut, sellAmount: 100 ether });
 
         address[] memory approveTokens = new address[](1);
         approveTokens[0] = address(mockToken);

--- a/test/COWFeeModule.t.sol
+++ b/test/COWFeeModule.t.sol
@@ -156,10 +156,7 @@ contract COWFeeModuleTest is Test {
         swapTokens[0] =
             COWFeeModule.SwapToken({ token: address(mockToken), buyAmount: buyAmount, sellAmount: sellAmount });
 
-        address[] memory approveTokens = new address[](1);
-        approveTokens[0] = address(mockToken);
-        uint256 previousAllowance = mockToken.allowance(address(settlement), vaultRelayer);
-        assertEq(previousAllowance, 0, "previousAllowance not 0");
+        address[] memory approveTokens = new address[](0);
 
         vm.prank(keeper);
         vm.expectRevert(COWFeeModule.BuyAmountTooSmall.selector);

--- a/ts/abi.ts
+++ b/ts/abi.ts
@@ -212,6 +212,19 @@ export const moduleAbi = [
     ],
     stateMutability: 'view',
   },
+  {
+    type: 'function',
+    name: 'minOut',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
 ];
 
 export const settlementAbi = [

--- a/ts/common.ts
+++ b/ts/common.ts
@@ -25,7 +25,7 @@ export interface IConfig {
   rpcUrl: string;
   network: keyof typeof networkSpecificConfigs;
   buyToken: string;
-  minOut: number;
+  minOut: bigint;
   targetSafe: string;
   receiver: string;
   buyTokenDecimals: number;

--- a/ts/common.ts
+++ b/ts/common.ts
@@ -28,7 +28,6 @@ export interface IConfig {
   minOut: bigint;
   targetSafe: string;
   receiver: string;
-  buyTokenDecimals: number;
   buyAmountSlippageBps: number;
   keeper: string;
   appData: string;

--- a/ts/cowfee.ts
+++ b/ts/cowfee.ts
@@ -169,7 +169,7 @@ export const swapTokens = async (
         .div(10000);
       return {
         ...token,
-        buyAmount: buyAmount.eq(0) ? BigNumber.from(1) : buyAmount,
+        buyAmount,
       };
     })
     .filter((token) => {

--- a/ts/cowfee.ts
+++ b/ts/cowfee.ts
@@ -115,16 +115,14 @@ export const getTokensToSwap = async (
         (quotes[i].status === 'fulfilled' &&
           (quotes[i] as PromiseFulfilledResult<OrderQuoteResponse>).value.quote
             .buyAmount) ||
-          0
+        0
       ),
     }))
     .filter((_, i) => quotes[i].status === 'fulfilled');
 
   // filter by min eth out
-  // const minOut = parseEther(config.minOut.toString());
-  const minOut = parseUnits(config.minOut.toString(), config.buyTokenDecimals);
   const minOutFiltered = quotesFiltered.filter((token) =>
-    BigNumber.from(token.tokenOut).gt(minOut)
+    BigNumber.from(token.tokenOut).gt(config.minOut)
   );
   return minOutFiltered;
 };

--- a/ts/cowfee.ts
+++ b/ts/cowfee.ts
@@ -162,15 +162,19 @@ export const swapTokens = async (
     throw new Error(`appData mismatch: ${appDataHex} != ${config.appData}`);
   }
 
-  const toSwapWithBuyAmount = toSwap.map((token) => {
-    const buyAmount = token.tokenOut
-      .mul(10000 - config.buyAmountSlippageBps)
-      .div(10000);
-    return {
-      ...token,
-      buyAmount: buyAmount.eq(0) ? BigNumber.from(1) : buyAmount,
-    };
-  });
+  const toSwapWithBuyAmount = toSwap
+    .map((token) => {
+      const buyAmount = token.tokenOut
+        .mul(10000 - config.buyAmountSlippageBps)
+        .div(10000);
+      return {
+        ...token,
+        buyAmount: buyAmount.eq(0) ? BigNumber.from(1) : buyAmount,
+      };
+    })
+    .filter((token) => {
+      return token.buyAmount.gt(config.minOut);
+    });
 
   // create orders
   const orders = await Promise.allSettled(

--- a/ts/cowfee.ts
+++ b/ts/cowfee.ts
@@ -108,22 +108,33 @@ export const getTokensToSwap = async (
       })
     )
   );
+  console.log(
+    'total tokens prefilter',
+    unfilteredWithBalanceAndAllowance.length
+  );
   const quotesFiltered = unfilteredWithBalanceAndAllowance
     .map((token, i) => ({
       ...token,
-      tokenOut: BigNumber.from(
+      buyAmount: BigNumber.from(
         (quotes[i].status === 'fulfilled' &&
           (quotes[i] as PromiseFulfilledResult<OrderQuoteResponse>).value.quote
             .buyAmount) ||
-        0
-      ),
+          0
+      )
+        .mul(10000 - config.buyAmountSlippageBps)
+        .div(10000),
     }))
     .filter((_, i) => quotes[i].status === 'fulfilled');
+  console.log(
+    'total tokens after filtering by quotes api',
+    quotesFiltered.length
+  );
 
   // filter by min eth out
   const minOutFiltered = quotesFiltered.filter((token) =>
-    BigNumber.from(token.tokenOut).gt(config.minOut)
+    BigNumber.from(token.buyAmount).gt(config.minOut)
   );
+  console.log('total tokens after filtering by minOut', minOutFiltered.length);
   return minOutFiltered;
 };
 
@@ -162,23 +173,9 @@ export const swapTokens = async (
     throw new Error(`appData mismatch: ${appDataHex} != ${config.appData}`);
   }
 
-  const toSwapWithBuyAmount = toSwap
-    .map((token) => {
-      const buyAmount = token.tokenOut
-        .mul(10000 - config.buyAmountSlippageBps)
-        .div(10000);
-      return {
-        ...token,
-        buyAmount,
-      };
-    })
-    .filter((token) => {
-      return token.buyAmount.gt(config.minOut);
-    });
-
   // create orders
   const orders = await Promise.allSettled(
-    toSwapWithBuyAmount.map((token) =>
+    toSwap.map((token) =>
       orderBookApi.sendOrder({
         sellToken: token.address,
         buyToken: config.buyToken,
@@ -212,7 +209,7 @@ export const swapTokens = async (
       .map((x) => (x as PromiseFulfilledResult<string>).value)
   );
   // only execute drip for successfully created orders
-  const toActuallySwap = toSwapWithBuyAmount.filter(
+  const toActuallySwap = toSwap.filter(
     (x, idx) => orders[idx].status === 'fulfilled'
   );
 


### PR DESCRIPTION
Keeper is able to place arbitrary orders hence it is possible that it can grief the protocol by placing order for the smallest amount possible that covers the fees and that way burn through all the fees.