### PR TITLE
feat: direct token transfer for weth

### DIFF
--- a/src/interfaces/IERC20.sol
+++ b/src/interfaces/IERC20.sol
@@ -3,4 +3,6 @@ pragma solidity 0.8.25;
 
 interface IERC20 {
     function approve(address, uint256) external;
+    function balanceOf(address) external view returns (uint256);
+    function transfer(address, uint256) external;
 }

--- a/test/COWFeeModule.t.sol
+++ b/test/COWFeeModule.t.sol
@@ -162,4 +162,14 @@ contract COWFeeModuleTest is Test {
         vm.expectRevert(COWFeeModule.BuyAmountTooSmall.selector);
         module.drip(approveTokens, swapTokens);
     }
+
+    function testDripWeth() external {
+        deal(WETH, address(settlement), minOut);
+        uint256 balanceBefore = IERC20(WETH).balanceOf(receiver);
+
+        vm.prank(keeper);
+        module.drip(new address[](0), new COWFeeModule.SwapToken[](0));
+        uint256 balanceAfter = IERC20(WETH).balanceOf(receiver);
+        assertEq(balanceAfter - balanceBefore, minOut, "drip didnt transfer weth as expected");
+    }
 }


### PR DESCRIPTION
Since cowswap doesn't quote for a swap from and to same token, the `toToken` never gets withdrawn. So we are adding a direct transfer interaction in the drip call if the `toToken` balance is > `minOut`.