### PR TITLE
Fetch logs in chunks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,5 +30,5 @@ jobs:
 
       - name: Run Forge tests
         run: |
-          forge test -vvv --rpc-url https://eth.llamarpc.com
+          forge test -vvv --rpc-url https://rpc.mevblocker.io
         id: test

--- a/index.ts
+++ b/index.ts
@@ -168,10 +168,12 @@ export const dripItAll = async () => {
     erc20Abi,
     provider
   );
+  const decimals = await buyTokenContract.decimals();
+  const expectedUnits = expectedBuy.div(ethers.BigNumber.from(10).pow(decimals));
   console.log(
     `Fee collection for chain ${config.network} initiated (${
       tokensToSwap.length
-    } orders). Expecting proceeds of ${expectedBuy.toString()} ${await buyTokenContract.symbol()}!\n\nFollow the progress at ${
+    } orders). Expecting proceeds of ${expectedUnits.toString()} ${await buyTokenContract.symbol()}!\n\nFollow the progress at ${
       networkSpecificConfigs[config.network].explorer
     }/address/${config.gpv2Settlement}`
   );

--- a/ts/explorer-apis.ts
+++ b/ts/explorer-apis.ts
@@ -111,9 +111,9 @@ const getDecimals = async (
 // Chunks the range (start..end) into subranges of size `n` (or shorter for the last chunk).
 const chunkRange = (start: number, end: number, chunkSize: number): [[number, number]] => {
     const chunks = [];
-    for (let i = start; i <= end; i += n) {
-        const chunk = Math.min(i + n - 1, end);
-        chunkgs.push([i, chunk]);
+    for (let i = start; i <= end; i += chunkSize) {
+        const chunk = Math.min(i + chunkSize - 1, end);
+        chunks.push([i, chunk]);
     }
     return chunks;
 }

--- a/ts/explorer-apis.ts
+++ b/ts/explorer-apis.ts
@@ -110,8 +110,8 @@ const getDecimals = async (
 
 // Chunks the range [start,end] into subranges of length `chunkSize`
 // (or shorter for the last chunk).
-const chunkRange = (start: number, end: number, chunkSize: number): [[number, number]] => {
-    const chunks = [];
+const chunkRange = (start: number, end: number, chunkSize: number): [number, number][] => {
+    const chunks: [number, number][] = [];
     for (let i = start; i <= end; i += chunkSize) {
         const chunk = Math.min(i + chunkSize - 1, end);
         chunks.push([i, chunk]);

--- a/ts/explorer-apis.ts
+++ b/ts/explorer-apis.ts
@@ -108,7 +108,8 @@ const getDecimals = async (
   return decimals;
 };
 
-// Chunks the range (start..end) into subranges of size `n` (or shorter for the last chunk).
+// Chunks the range [start,end] into subranges of length `chunkSize`
+// (or shorter for the last chunk).
 const chunkRange = (start: number, end: number, chunkSize: number): [[number, number]] => {
     const chunks = [];
     for (let i = start; i <= end; i += chunkSize) {


### PR DESCRIPTION
When querying an RPC node for huge range of events it can return an error when the response size gets exceeded.
This error prevented the fee withdrawal to work correctly in a week where a lot of trades happened.

This PR works around this limitation by requesting logs in chunks instead of the whole range at once.

Mentioned error:
```
Error: Log response size exceeded. You can make eth_getLogs requests with up to a 2K block range and no limit on the response size, or you can request any block range with a cap of 10K logs in the response. Based on your parameters and the response size limit, this block range should work: [0x13b3ac6, 0x13b6ec9]
```