### PR TITLE
Allow keeper to change the minOut

### DIFF
--- a/src/COWFeeModule.sol
+++ b/src/COWFeeModule.sol
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.25;
 
-import { ISafe } from "./interfaces/ISafe.sol";
-import { IGPv2Settlement } from "./interfaces/IGPv2Settlement.sol";
-import { IERC20 } from "./interfaces/IERC20.sol";
-import { GPv2Order } from "./libraries/GPv2Order.sol";
+import {ISafe} from "./interfaces/ISafe.sol";
+import {IGPv2Settlement} from "./interfaces/IGPv2Settlement.sol";
+import {IERC20} from "./interfaces/IERC20.sol";
+import {GPv2Order} from "./libraries/GPv2Order.sol";
 
 contract COWFeeModule {
     error OnlyKeeper();
     error BuyAmountTooSmall();
+    error MinOutZero();
 
     // not public to save deployment costs
     ISafe public immutable targetSafe;
@@ -19,7 +20,7 @@ contract COWFeeModule {
     IGPv2Settlement public immutable settlement;
     address public immutable vaultRelayer;
     address public immutable receiver;
-    uint256 public immutable minOut;
+    uint256 public minOut;
 
     struct Revocation {
         address token;
@@ -56,6 +57,13 @@ contract COWFeeModule {
         domainSeparator = settlement.domainSeparator();
         appData = _appData;
         receiver = _receiver;
+        minOut = _minOut;
+    }
+
+    /// @notice Update the minimum output amount
+    /// @param _minOut The new minimum output amount
+    function setMinOut(uint256 _minOut) external onlyKeeper {
+        if (_minOut == 0) revert MinOutZero();
         minOut = _minOut;
     }
 

--- a/test/COWFeeModule.t.sol
+++ b/test/COWFeeModule.t.sol
@@ -67,6 +67,21 @@ contract COWFeeModuleTest is Test {
         module.setMinOut(1);
     }
 
+    function testSetMinOut() external {
+        uint256 newMinOut = 0.02 ether;
+        assertNotEq(module.minOut(), newMinOut, "minOut not 0");
+
+        vm.prank(keeper);
+        module.setMinOut(newMinOut);
+        assertEq(module.minOut(), newMinOut, "minOut hasn't changed to the new value");
+    }
+
+    function testSetMinOutZero() external {
+        vm.expectRevert(COWFeeModule.MinOutZero.selector);
+        vm.prank(keeper);
+        module.setMinOut(0);
+    }
+
     function testApprove() external {
         uint256 currentAllowance = mockToken.allowance(address(settlement), address(vaultRelayer));
         assertEq(currentAllowance, 0, "current allowance not 0");


### PR DESCRIPTION
Modify the contract to allow the keeper to change the thresholds.

## Motivation
Because the `toToken` and the `gasPrices` can change a lot over time, and because it is annoying to deploy a new module and replace it in the multisig.

## Changes
Adds a new method `setMinOut` that allows changing the `minOut`. 

It also adds some unit tests to verify
- Only keeper can invoke the method
- Setting a non-zero value modifies the contract storage
- Setting a zero value, reverts

## Not included
To keep things simple, i didn't make a script to send the transaction.

I think its so trivial to change using EtherScan or any other method (its a simple TX to the module).