### PR TITLE
Include wrapped eth into the "expected proceeds" message

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 import { formatUnits } from "ethers/lib/utils";
-import { getTokensToSwap, swapTokens } from "./ts/cowfee";
+import { getEthToWrap, getTokensToSwap, swapTokens } from "./ts/cowfee";
 import {
   IConfig,
   networkSpecificConfigs,
@@ -150,6 +150,8 @@ export const dripItAll = async () => {
 
   const signer = new ethers.Wallet(config.privateKey, provider);
 
+  const ethToWrap = await getEthToWrap(config, provider);
+
   const tokensToSwap = await getTokensToSwap(config, provider);
   console.log(
     "Tokens to swap:",
@@ -181,8 +183,10 @@ export const dripItAll = async () => {
     erc20Abi,
     provider
   );
+
+  const expectedToReceive = expectedBuy.add(ethToWrap);
   const decimals = await buyTokenContract.decimals();
-  const expectedUnits = ethers.utils.formatUnits(expectedBuy, decimals);
+  const expectedUnits = ethers.utils.formatUnits(expectedToReceive, decimals);
   const expectedUnitsFormatted = parseFloat(expectedUnits).toFixed(2);
   console.log(
     `Fee collection for chain ${config.network} initiated (${

--- a/ts/cowfee.ts
+++ b/ts/cowfee.ts
@@ -142,6 +142,14 @@ export const getTokensToSwap = async (
   return minOutFiltered;
 };
 
+export async function getEthToWrap(
+  config: IConfig,
+  provider: ethers.providers.JsonRpcProvider
+) {
+  const ethBalance = await provider.getBalance(config.gpv2Settlement);
+  return ethBalance.gte(config.minOut) ? ethBalance : BigNumber.from(0);
+}
+
 // get COWFeeModule appData
 export const getAppData = async () => {
   const appDataDoc = {


### PR DESCRIPTION
Adds the wrapped ETH amount into the message that describes how much is expected out of the drip.

## Test
1. Send more than `minOut` ETH to the settlement contract in Sepolia (//explorer.cow.fi/sepolia/address/0x9008D19f58AAbD9eD0D60971565AA8510560ab41)
2. Execute the script
3. Check the drip message matches the drip transaction


In my case I saw this message:
<img width="807" alt="image" src="https://github.com/user-attachments/assets/e3253e43-bf3e-493f-beab-18e7ad0e8193" />

I received approximately 0.06 WETH from dumping tokens:
<img width="1506" alt="image" src="https://github.com/user-attachments/assets/17844619-f720-403d-81f0-0ac85f9687cc" />

I received 1 ETH in the drip TX:
https://sepolia.etherscan.io/tx/0x43e612bf9f687ba115d405d09229c1cd3ac849c86b9543a093ec6854c3857930

