### PR TITLE
Make the drip tx more resilient

### DIFF
--- a/ts/common.ts
+++ b/ts/common.ts
@@ -1,7 +1,16 @@
 import { OrderBookApi, SupportedChainId } from "@cowprotocol/cow-sdk";
-import { ethers } from "ethers";
+import { BigNumber, ContractTransaction, ethers } from "ethers";
+import {
+  TransactionReceipt,
+  TransactionRequest,
+} from "@ethersproject/abstract-provider";
 import { multicall3Abi } from "./abi";
 import readline from "readline";
+
+const GAS_INCREASE_STEP = 10; // 10% increase per retry
+const MAX_GAS_INCREASE = 120; // 200% of original gas price
+const WAIT_TIME_FOR_MAX_GAS_PRICE = 100 * 1000; // 1 hour
+const TIMEOUT_BEFORE_INCREASING_GAS_PRICE = 1 * 1000; // 5 min
 
 interface NetworkDetails {
   rpcUrl: string;
@@ -174,4 +183,420 @@ export async function confirmMessage(message: string) {
       resolve(answer.toLowerCase() === "yes" || answer.toLowerCase() === "y");
     });
   });
+}
+
+class TimeoutError extends Error {
+  constructor(operationName: string, timeoutMs: number) {
+    super(`${operationName} timed out after ${timeoutMs}ms`);
+    this.name = "TimeoutError";
+  }
+}
+
+/**
+ * Creates a promise that rejects after the specified timeout
+ * @param timeoutMs - Timeout in milliseconds
+ * @param operationName - Name of the operation that timed out
+ *
+ * @returns A promise that rejects after the timeout
+ */
+export function createTimeoutPromise(
+  timeoutMs: number,
+  operationName: string
+): Promise<never> {
+  return new Promise<never>((_, reject) => {
+    setTimeout(
+      () => reject(new TimeoutError(operationName, timeoutMs)),
+      timeoutMs
+    );
+  });
+}
+
+export function formatGasPrice(gasPrice: GasPriceData) {
+  if (isGasPriceDataEIP1559(gasPrice)) {
+    return `maxFeePerGas=${gasPrice.maxFeePerGas.toString()}, maxPriorityFeePerGas=${gasPrice.maxPriorityFeePerGas.toString()}`;
+  }
+  return `gasPrice=${gasPrice.gasPrice.toString()}`;
+}
+
+export async function waitForTransactionWithTimeout(
+  tx: ContractTransaction,
+  timeoutMs: number,
+  operationName: string
+): Promise<TransactionReceipt> {
+  console.log(`Waiting for ${operationName} transaction:`, tx.hash);
+  const receipt = await withTimeout(tx.wait(), timeoutMs, operationName);
+
+  throwIfFailed(receipt, operationName);
+
+  console.log(`${operationName} transaction was mined:`, tx.hash);
+
+  return receipt;
+}
+
+/**
+ * Wraps a promise with a timeout, rejecting if the original promise doesn't resolve in time
+ *
+ * @param promise - The promise to wrap with a timeout
+ * @param timeoutMs - Timeout in milliseconds
+ * @param operationName - Name of the operation for the timeout error message
+ *
+ * @returns A promise that resolves with the original promise result or rejects on timeout
+ */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  operationName: string
+): Promise<T> {
+  return Promise.race([
+    promise,
+    createTimeoutPromise(timeoutMs, operationName),
+  ]);
+}
+
+export interface TransactionParams {
+  /**
+   * The signer to use for the transaction
+   */
+  signer: ethers.Signer;
+
+  /**
+   * The transaction request to execute
+   */
+  txRequest: TransactionRequest;
+
+  /**
+   * The name of the operation to execute. Only used for logging.
+   */
+  operationName: string;
+
+  /**
+   * The maximum gas increase percentage. Default is 200% of the original gas price.
+   */
+  maxGasIncreasePercentage?: number;
+
+  /**
+   * The wait time for the max gas price. Default is 1 hour.
+   */
+  waitTimeForMaxGasPrice?: number;
+
+  /**
+   * The timeout before increasing the gas price. Default is 5 minutes.
+   */
+  timeoutBeforeIncreasingGasPrice?: number;
+}
+
+type GasPriceData = GasPriceDataEIP1559 | GasPriceDataLegacy;
+
+function isGasPriceDataEIP1559(
+  gasPriceData: GasPriceData
+): gasPriceData is GasPriceDataEIP1559 {
+  return (
+    "maxFeePerGas" in gasPriceData && "maxPriorityFeePerGas" in gasPriceData
+  );
+}
+
+interface GasPriceDataEIP1559 {
+  maxFeePerGas: BigNumber;
+  maxPriorityFeePerGas: BigNumber;
+}
+
+interface GasPriceDataLegacy {
+  gasPrice: BigNumber;
+}
+
+async function getGasPriceData(
+  provider: ethers.providers.JsonRpcProvider | ethers.Signer
+): Promise<GasPriceData> {
+  const feeData = await provider.getFeeData();
+
+  if (feeData.maxFeePerGas && feeData.maxPriorityFeePerGas) {
+    return {
+      maxFeePerGas: feeData.maxFeePerGas,
+      maxPriorityFeePerGas: feeData.maxPriorityFeePerGas,
+    };
+  }
+
+  return {
+    gasPrice: feeData.gasPrice || (await provider.getGasPrice()),
+  };
+}
+
+interface GasPriceIncreaseResult {
+  currentGasPrice: GasPriceData;
+  baseTxRequest: TransactionRequest;
+  usingMaximumGasPrice: boolean;
+}
+
+function increaseByPercentage(value: BigNumber, percentage: number): BigNumber {
+  return value.mul(100 + percentage).div(100);
+}
+
+/**
+ * Increase gas price by a percentage, capped to the maximum gas price
+ * @param params - Parameters for the gas price increase
+ * @returns The updated gas price and transaction request
+ */
+function increaseGasPrice(params: {
+  currentGasPrice: GasPriceData;
+  baseTxRequest: TransactionRequest;
+  maxGasPrice: BigNumber;
+}): GasPriceIncreaseResult {
+  const { currentGasPrice, baseTxRequest, maxGasPrice } = params;
+
+  let updatedGasPrice: GasPriceData;
+  let usingMaximumGasPrice: boolean;
+  if (isGasPriceDataEIP1559(currentGasPrice)) {
+    const maxFeePerGas = increaseByPercentage(
+      currentGasPrice.maxFeePerGas,
+      GAS_INCREASE_STEP
+    );
+
+    // Increase max fee and max priority fee by 10% (capped to maxGasPrice)
+    updatedGasPrice = {
+      maxFeePerGas: maxFeePerGas.gt(maxGasPrice) ? maxGasPrice : maxFeePerGas,
+      maxPriorityFeePerGas: increaseByPercentage(
+        currentGasPrice.maxPriorityFeePerGas,
+        GAS_INCREASE_STEP
+      ),
+    };
+    usingMaximumGasPrice = updatedGasPrice.maxFeePerGas.eq(maxGasPrice);
+
+    // Delete legacy fields (if they exist). This is an EIP-1559 transaction. They should not be present anyways, since the RPC provider should be consistent (either always EIP-1559 or always legacy)
+    delete baseTxRequest.gasPrice;
+
+    // Update transaction request with new gas price
+    baseTxRequest.maxFeePerGas = updatedGasPrice.maxFeePerGas;
+    baseTxRequest.maxPriorityFeePerGas = updatedGasPrice.maxPriorityFeePerGas;
+  } else {
+    // Increase legacy gas price by 10%
+    const gasPrice = increaseByPercentage(
+      currentGasPrice.gasPrice,
+      GAS_INCREASE_STEP
+    );
+    updatedGasPrice = {
+      gasPrice: gasPrice.gt(maxGasPrice) ? maxGasPrice : gasPrice,
+    };
+    usingMaximumGasPrice = updatedGasPrice.gasPrice.eq(maxGasPrice);
+
+    // Delete EIP-1559 fields (if they exist). This is a legacy transaction. They should not be present anyways, since the RPC provider should be consistent (either always EIP-1559 or always legacy)
+    delete baseTxRequest.maxFeePerGas;
+    delete baseTxRequest.maxPriorityFeePerGas;
+
+    // Add new bumped legacy gas price
+    baseTxRequest.gasPrice = updatedGasPrice.gasPrice;
+  }
+
+  return {
+    currentGasPrice: updatedGasPrice,
+    baseTxRequest,
+    usingMaximumGasPrice,
+  };
+}
+
+function throwIfFailed(receipt: TransactionReceipt, operationName: string) {
+  if (receipt.status === 0) {
+    throw new Error(
+      `${operationName} transaction failed: ${receipt.transactionHash}`
+    );
+  }
+}
+
+/**
+ * Executes a transaction with automatic gas price increases, timeout handling, and transaction replacement handling.
+ * It will use EIP-1559 if the transaction request includes a maxFeePerGas, otherwise it will use legacy gas price (for networks that don't support EIP-1559).
+ *
+ * @param params - Transaction parameters including signer, request, and operation name
+ * @returns The transaction receipt
+ * @throws Error if transaction fails or times out after maximum retries
+ */
+export async function executeTransaction(
+  params: TransactionParams
+): Promise<string | null> {
+  const {
+    signer,
+    txRequest,
+    operationName,
+    maxGasIncreasePercentage = MAX_GAS_INCREASE,
+    waitTimeForMaxGasPrice = WAIT_TIME_FOR_MAX_GAS_PRICE,
+    timeoutBeforeIncreasingGasPrice = TIMEOUT_BEFORE_INCREASING_GAS_PRICE,
+  } = params;
+
+  // Get initial fee estimation
+  const originalGasPrice = await getGasPriceData(signer);
+
+  // Calculate the maximum gas price we are willing to pay
+  const maxGasPrice = increaseByPercentage(
+    isGasPriceDataEIP1559(originalGasPrice)
+      ? originalGasPrice.maxFeePerGas
+      : originalGasPrice.gasPrice,
+    maxGasIncreasePercentage - 100
+  );
+
+  let currentGasPrice = { ...originalGasPrice };
+  const baseTxRequest: TransactionRequest = {
+    ...txRequest,
+    ...currentGasPrice,
+  };
+
+  let tx: ContractTransaction;
+  while (true) {
+    try {
+      // Send the transaction
+      tx = await signer.sendTransaction(baseTxRequest);
+
+      // Wait for the transaction to be mined (or timeout to increase gas price)
+      const receipt = await waitForTransactionWithTimeout(
+        tx,
+        timeoutBeforeIncreasingGasPrice,
+        operationName
+      );
+
+      return receipt.transactionHash;
+    } catch (error) {
+      // Handle transaction replacement error
+      const replacedTxReceipt = await handleTransactionReplacementError(
+        error,
+        signer.provider!,
+        operationName
+      );
+      if (replacedTxReceipt) {
+        return replacedTxReceipt.transactionHash;
+      }
+
+      // Handle nonce has already been used (it happens if the previous transaction was mined before we send a new one with updated gas price)
+      if (hasNonceAlreadyBeenUsed(error, signer)) {
+        console.log(
+          `Nonce has already been used. A previous transaction has been minded`
+        );
+        return null;
+      }
+
+      // Re-throw the error if it's not a timeout error
+      if (!(error instanceof TimeoutError)) {
+        throw error;
+      }
+
+      // Increase gas price
+      const {
+        currentGasPrice: updatedGasPrice,
+        baseTxRequest: updatedTxRequest,
+        usingMaximumGasPrice,
+      } = increaseGasPrice({
+        currentGasPrice,
+        baseTxRequest,
+        maxGasPrice,
+      });
+
+      // Prepare for next iteration
+      currentGasPrice = updatedGasPrice;
+      Object.assign(baseTxRequest, updatedTxRequest);
+
+      if (usingMaximumGasPrice) {
+        // Maximum gas price reached. Wait for longer with no more retries
+        return handleMaximumGasPriceReached(
+          tx!,
+          signer.provider!,
+          currentGasPrice,
+          waitTimeForMaxGasPrice,
+          operationName
+        );
+      } else {
+        // Re-try with increased gas price
+        console.log(
+          `Retrying with increased gas price`,
+          formatGasPrice(currentGasPrice)
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Handles a transaction replacement error by waiting for the replacement transaction to be mined.
+ * @param error - The error to handle
+ * @param signer - The signer to use to wait for the replacement transaction
+ * @param operationName - The name of the operation to execute. Only used for logging.
+ * @returns The receipt of the replacement transaction if the error is a transaction replacement error, otherwise undefined
+ */
+async function handleTransactionReplacementError(
+  error: unknown,
+  provider: ethers.providers.Provider,
+  operationName: string
+): Promise<TransactionReceipt | undefined> {
+  const replacementTxHash = getReplacementTxHash(error);
+  if (replacementTxHash) {
+    console.log(`Transaction was replaced with: ${replacementTxHash}`);
+    const receipt = await provider.waitForTransaction(replacementTxHash);
+    console.log(`${operationName} transaction was mined:`, replacementTxHash);
+    return receipt;
+  }
+
+  return undefined;
+}
+
+/**
+ * Extracts the hash of the replacement transaction from the error (if the error is a transaction replacement error)
+ * @param error - The error to handle
+ * @returns The transaction hash of the replacement transaction if the error is a transaction replacement error, otherwise undefined
+ */
+function getReplacementTxHash(error: unknown): string | undefined {
+  if (
+    error instanceof Error &&
+    "replacement" in error &&
+    typeof error.replacement === "object" &&
+    error.replacement !== null &&
+    "hash" in error.replacement &&
+    typeof error.replacement.hash === "string"
+  ) {
+    return error.replacement.hash;
+  }
+
+  return undefined;
+}
+
+function hasNonceAlreadyBeenUsed(error: unknown, signer: ethers.Signer) {
+  return (
+    error instanceof Error &&
+    error.message.includes("nonce has already been used")
+  );
+}
+
+async function handleMaximumGasPriceReached(
+  tx: ContractTransaction,
+  provider: ethers.providers.Provider,
+  currentGasPrice: GasPriceData,
+  waitTimeForMaxGasPrice: number,
+  operationName: string
+): Promise<string> {
+  // If we reached the maximum. Wait for longer with no more retries.
+  console.log(
+    `Transaction still pending after reaching max gas price. Waiting for ${
+      waitTimeForMaxGasPrice / 1000
+    } seconds before giving up...`,
+    formatGasPrice(currentGasPrice)
+  );
+  try {
+    const receipt = await waitForTransactionWithTimeout(
+      tx,
+      waitTimeForMaxGasPrice,
+      `Final ${operationName}`
+    );
+
+    return receipt.transactionHash;
+  } catch (finalError: unknown) {
+    // Handle transaction replacement error
+    const replacedTxReceipt = await handleTransactionReplacementError(
+      finalError,
+      provider,
+      operationName
+    );
+
+    if (replacedTxReceipt) {
+      return replacedTxReceipt.transactionHash;
+    } else {
+      console.log(`${operationName} failed after maximum wait time`);
+      // Re-throw the error if it's not a transaction replacement error
+      throw finalError;
+    }
+  }
 }

--- a/ts/common.ts
+++ b/ts/common.ts
@@ -275,12 +275,12 @@ export interface TransactionParams {
   maxGasIncreasePercentage?: number;
 
   /**
-   * The wait time for the max gas price. Default is 1 hour.
+   * The wait time for the max gas price in milliseconds. Default is 1 hour.
    */
   waitTimeForMaxGasPrice?: number;
 
   /**
-   * The timeout before increasing the gas price. Default is 5 minutes.
+   * The timeout in milliseconds before increasing the gas price. Default is 5 minutes.
    */
   timeoutBeforeIncreasingGasPrice?: number;
 }

--- a/ts/common.ts
+++ b/ts/common.ts
@@ -373,10 +373,10 @@ function increaseGasPrice(params: {
       currentGasPrice.gasPrice,
       GAS_INCREASE_STEP
     );
+    usingMaximumGasPrice = gasPrice.gte(maxGasPrice);
     updatedGasPrice = {
-      gasPrice: gasPrice.gt(maxGasPrice) ? maxGasPrice : gasPrice,
+      gasPrice: usingMaximumGasPrice ? maxGasPrice : gasPrice,
     };
-    usingMaximumGasPrice = updatedGasPrice.gasPrice.eq(maxGasPrice);
 
     // Delete EIP-1559 fields (if they exist). This is a legacy transaction. They should not be present anyways, since the RPC provider should be consistent (either always EIP-1559 or always legacy)
     delete baseTxRequest.maxFeePerGas;

--- a/ts/common.ts
+++ b/ts/common.ts
@@ -351,7 +351,7 @@ function increaseGasPrice(params: {
       GAS_INCREASE_STEP
     );
 
-    // Increase max fee and max priority fee by 10% (capped to maxGasPrice)
+    // Increase max fee and max priority fee by the step percentage (capped to maxGasPrice)
     updatedGasPrice = {
       maxFeePerGas: maxFeePerGas.gt(maxGasPrice) ? maxGasPrice : maxFeePerGas,
       maxPriorityFeePerGas: increaseByPercentage(
@@ -368,7 +368,7 @@ function increaseGasPrice(params: {
     baseTxRequest.maxFeePerGas = updatedGasPrice.maxFeePerGas;
     baseTxRequest.maxPriorityFeePerGas = updatedGasPrice.maxPriorityFeePerGas;
   } else {
-    // Increase legacy gas price by 10%
+    // Increase legacy gas price by the step percentage
     const gasPrice = increaseByPercentage(
       currentGasPrice.gasPrice,
       GAS_INCREASE_STEP

--- a/ts/common.ts
+++ b/ts/common.ts
@@ -7,8 +7,8 @@ import {
 import { multicall3Abi } from "./abi";
 import readline from "readline";
 
-const GAS_INCREASE_STEP = 10; // 10% increase per retry
-const MAX_GAS_INCREASE = 120; // 200% of original gas price
+const GAS_INCREASE_STEP = 10; // +10% increase per retry
+const MAX_GAS_INCREASE = 100; // +100% of original gas price
 const WAIT_TIME_FOR_MAX_GAS_PRICE = 100 * 1000; // 1 hour
 const TIMEOUT_BEFORE_INCREASING_GAS_PRICE = 1 * 1000; // 5 min
 
@@ -429,7 +429,7 @@ export async function executeTransaction(
     isGasPriceDataEIP1559(originalGasPrice)
       ? originalGasPrice.maxFeePerGas
       : originalGasPrice.gasPrice,
-    maxGasIncreasePercentage - 100
+    maxGasIncreasePercentage
   );
 
   let currentGasPrice = { ...originalGasPrice };

--- a/ts/common.ts
+++ b/ts/common.ts
@@ -9,8 +9,8 @@ import readline from "readline";
 
 const GAS_INCREASE_STEP = 10; // +10% increase per retry
 const MAX_GAS_INCREASE = 100; // +100% of original gas price
-const WAIT_TIME_FOR_MAX_GAS_PRICE = 100 * 1000; // 1 hour
-const TIMEOUT_BEFORE_INCREASING_GAS_PRICE = 1 * 1000; // 5 min
+const WAIT_TIME_FOR_MAX_GAS_PRICE_MILLIS = 3600 * 1000; // 1 hour
+const TIMEOUT_BEFORE_INCREASING_GAS_PRICE_MILLIS = 5 * 60 * 1000; // 5 min
 
 interface NetworkDetails {
   rpcUrl: string;


### PR DESCRIPTION
> Note for reviewers: You might prefer to review only the follow up PR #54. After this PR I decided to do a refactor because the code was asking to be divided. The `common.ts` and the `cowfee.ts` were big monoliths. It might be easier to just review the follow-up. 

> Disclaimer: This PR might be overkill. The utility function `executeTransaction` is  a bit complex, and probably we would have gotten by with less features, but I went over the rabbit hole to debug the issue and implement the gas increments. 
It should be more robust now, so I think is worth using, plus the complexity is in a single utility function `executeTransaction`.

## Context
We observed that some txs were taking too long to mine in some cases.  This PR aims to make the drip tx more robust.

## Main change
This PR mainly replaces the:
```ts
const dripTxReceipt = await dripTx.wait();
```

with:
```
await executeTransaction({ txRequest, ... });
````

`executeTransaction` will execute the transaction, but adding the following features:
- Adds `EIP-1559` support. Before was using legacy, which I think was big reason why it was less reliable
- If `EIP-1559` is not available, fallback to legacy gas estimation
- It will continue to increase the gas price automatically in in increments of `10%` each `5 min` (if the tx doesn't mine)
- It will cap the maximum gas at `200%` the first estimation. After we reach `200%`, it will wait 1h for the transaction to mine, after that, it will timeout.

Additionally, because it replaces transactions, it also handles gracefully:
- Replacement of transaction: If it detects a tx that replaced another one. In that case, it will wait for this other one to mine and 
- Nonce too low: It could happen if another transaction mines between the timeout, and sending the new replacement transaction. 

Lastly, shows some convenient additional logging messages
- Shows the gas prices used
- When it replaces a tx, it shows the new prices
- Logs when the TX is sent, and when is mined
- Also, all the edge cases (like tx replaced)
- Print the account address for the keeper


Example: Re-attemt
<img width="786" alt="Screenshot at Jun 07 00-20-33" src="https://github.com/user-attachments/assets/1f84450b-b643-4cd1-98d5-f3ac340c9781" />

Example: When we reach the maximum 200%
![image](https://github.com/user-attachments/assets/5951fcad-a709-40b9-aac9-92a489575b00)

Example: Nonce has already been used
<img width="745" alt="image" src="https://github.com/user-attachments/assets/0dd1873a-7495-47a2-b24c-63403325a6e4" />


## Test in Sepolia
1. Send `0.3 ETH` to the settlement contract `0x9008D19f58AAbD9eD0D60971565AA8510560ab41`  in Sepolia
2. Run the script
3. Verify the result of the execution

You can experiment with different timeout times, to stress it

```bash
PRIVATE_KEY=<pk> yarn ts-node index.ts \
  --network sepolia \
  --max-orders 250 \
  --rpc-url <your-rpc>
  --buy-amount-slippage-bps 100 \
  --module 0x456ca0e6abf780140583ef3c8b5be2e7804278a6 \
  --token-list-strategy chain \
  --lookback-range 1000 \
  -c
```